### PR TITLE
fix: Definition for rule 'import-helpers/order-imports' was not found

### DIFF
--- a/gobarber-web/.eslintrc.json
+++ b/gobarber-web/.eslintrc.json
@@ -22,7 +22,7 @@
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
-  "plugins": ["react", "react-hooks", "@typescript-eslint", "prettier"],
+  "plugins": ["react", "react-hooks", "@typescript-eslint", "prettier", "eslint-plugin-import-helpers"],
   "rules": {
     "prettier/prettier": "error",
     "react/jsx-one-expression-per-line": "off",


### PR DESCRIPTION
Estava faltando um configuração no plugin do arquivo ".eslintrc.json". Com essa adição o problema foi resolvido.

Aqui temos uma referência que faz a sugestão da configuração https://github.com/Tibfib/eslint-plugin-import-helpers/blob/master/docs/rules/order-imports.md#usage 